### PR TITLE
fix #13: Add footerBuilder to keyboardAction

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,22 @@ This causes a lot of inconvenience for users, so this package allows adding func
 - Done button for the keyboard ( You can customize the button).
 - Move up/down between your Textfields.
 - Keyboard Bar customization.
+- Custom footer widget below keyboard bar
 - You can use it for Android, iOS or both platforms.
 - Compatible with Dialog.
 
+Example of the custom footer: 
+
+<img width="350" alt="Screen Shot 2019-05-22 at 5 46 50 PM" src="https://user-images.githubusercontent.com/3268245/58218221-0409f200-7cbb-11e9-91d8-592f2e99fa8a.png">
+
+For more fun, use that widget as a custom keyboard with your custom input:
+
+<img width="350" alt="Screen Shot 2019-05-22 at 5 46 54 PM" src="https://user-images.githubusercontent.com/3268245/58218234-0ec48700-7cbb-11e9-81b6-e61658f4d200.png">
+
+
 ## Getting started
 
-You should ensure that you add the router as a dependency in your flutter project.
+You should ensure that you add the dependency in your flutter project.
 ```yaml
 dependencies:
   keyboard_actions: "^2.0.1"

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ This causes a lot of inconvenience for users, so this package allows adding func
 
 Example of the custom footer: 
 
-<img width="350" alt="Screen Shot 2019-05-22 at 5 46 50 PM" src="https://user-images.githubusercontent.com/3268245/58218221-0409f200-7cbb-11e9-91d8-592f2e99fa8a.png">
+<img width="250" alt="Screen Shot 2019-05-22 at 5 46 50 PM" src="https://user-images.githubusercontent.com/3268245/58218221-0409f200-7cbb-11e9-91d8-592f2e99fa8a.png">
 
 For more fun, use that widget as a custom keyboard with your custom input:
 
-<img width="350" alt="Screen Shot 2019-05-22 at 5 46 54 PM" src="https://user-images.githubusercontent.com/3268245/58218234-0ec48700-7cbb-11e9-81b6-e61658f4d200.png">
+<img width="250" alt="Screen Shot 2019-05-22 at 5 46 54 PM" src="https://user-images.githubusercontent.com/3268245/58218234-0ec48700-7cbb-11e9-81b6-e61658f4d200.png">
 
 
 ## Getting started

--- a/example/lib/content.dart
+++ b/example/lib/content.dart
@@ -15,6 +15,7 @@ class _ContentState extends State<Content> {
   final FocusNode _nodeText4 = FocusNode();
   final FocusNode _nodeText5 = FocusNode();
   final FocusNode _nodeText6 = FocusNode();
+  final FocusNode _nodeText7 = FocusNode();
 
   /// Creates the [KeyboardActionsConfig] to hook up the fields
   /// and their focus nodes to our [FormKeyboardActions].
@@ -58,13 +59,19 @@ class _ContentState extends State<Content> {
         ),
         KeyboardAction(
           focusNode: _nodeText5,
-        ),
-        KeyboardAction(
-          focusNode: _nodeText6,
           closeWidget: Padding(
             padding: EdgeInsets.all(5.0),
             child: Text("CLOSE"),
           ),
+        ),
+        KeyboardAction(
+          focusNode: _nodeText6,
+          footer: PreferredSize(
+              child: SizedBox(height: 40, child: Center(child: Text('Custom Footer'),)),
+              preferredSize: Size.fromHeight(40)),
+        ),
+        KeyboardAction(
+          focusNode: _nodeText7,
           footer: ColorPickerKeyboard.instance,
         ),
       ],
@@ -86,7 +93,6 @@ class _ContentState extends State<Content> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: <Widget>[
-            SizedBox(height: 200,),
             TextField(
               keyboardType: TextInputType.number,
               focusNode: _nodeText1,
@@ -122,11 +128,17 @@ class _ContentState extends State<Content> {
                 hintText: "Input Number with Custom Close Widget",
               ),
             ),
-//            SizedBox(height: 40,),
-            ColorInput(
+            TextField(
+              keyboardType: TextInputType.number,
               focusNode: _nodeText6,
               decoration: InputDecoration(
-                  hintText: 'Input Color with Custom Footer',
+                hintText: "Input Number with Custom Footer",
+              ),
+            ),
+            ColorInput(
+              focusNode: _nodeText7,
+              decoration: InputDecoration(
+                  hintText: 'Input Color',
               ),
             ),
           ],

--- a/example/lib/content.dart
+++ b/example/lib/content.dart
@@ -66,13 +66,13 @@ class _ContentState extends State<Content> {
         ),
         KeyboardAction(
           focusNode: _nodeText6,
-          footer: PreferredSize(
+          footerBuilder: (_) => PreferredSize(
               child: SizedBox(height: 40, child: Center(child: Text('Custom Footer'),)),
               preferredSize: Size.fromHeight(40)),
         ),
         KeyboardAction(
           focusNode: _nodeText7,
-          footer: ColorPickerKeyboard.instance,
+          footerBuilder: (_) => ColorPickerKeyboard.instance,
         ),
       ],
     );

--- a/example/lib/content.dart
+++ b/example/lib/content.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:keyboard_actions/keyboard_actions.dart';
 
+import 'custom_input.dart';
+
 class Content extends StatefulWidget {
   @override
   _ContentState createState() => _ContentState();
@@ -12,6 +14,7 @@ class _ContentState extends State<Content> {
   final FocusNode _nodeText3 = FocusNode();
   final FocusNode _nodeText4 = FocusNode();
   final FocusNode _nodeText5 = FocusNode();
+  final FocusNode _nodeText6 = FocusNode();
 
   /// Creates the [KeyboardActionsConfig] to hook up the fields
   /// and their focus nodes to our [FormKeyboardActions].
@@ -55,10 +58,14 @@ class _ContentState extends State<Content> {
         ),
         KeyboardAction(
           focusNode: _nodeText5,
+        ),
+        KeyboardAction(
+          focusNode: _nodeText6,
           closeWidget: Padding(
             padding: EdgeInsets.all(5.0),
             child: Text("CLOSE"),
           ),
+          footer: ColorPickerKeyboard.instance,
         ),
       ],
     );
@@ -76,47 +83,53 @@ class _ContentState extends State<Content> {
     return Center(
       child: Padding(
         padding: const EdgeInsets.all(15.0),
-        child: SingleChildScrollView(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: <Widget>[
-              TextField(
-                keyboardType: TextInputType.number,
-                focusNode: _nodeText1,
-                decoration: InputDecoration(
-                  hintText: "Input Number",
-                ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            SizedBox(height: 200,),
+            TextField(
+              keyboardType: TextInputType.number,
+              focusNode: _nodeText1,
+              decoration: InputDecoration(
+                hintText: "Input Number",
               ),
-              TextField(
-                keyboardType: TextInputType.text,
-                focusNode: _nodeText2,
-                decoration: InputDecoration(
-                  hintText: "Input Text with Custom Close Widget",
-                ),
+            ),
+            TextField(
+              keyboardType: TextInputType.text,
+              focusNode: _nodeText2,
+              decoration: InputDecoration(
+                hintText: "Input Text with Custom Close Widget",
               ),
-              TextField(
-                keyboardType: TextInputType.number,
-                focusNode: _nodeText3,
-                decoration: InputDecoration(
-                  hintText: "Input Number with Custom Action",
-                ),
+            ),
+            TextField(
+              keyboardType: TextInputType.number,
+              focusNode: _nodeText3,
+              decoration: InputDecoration(
+                hintText: "Input Number with Custom Action",
               ),
-              TextField(
-                keyboardType: TextInputType.text,
-                focusNode: _nodeText4,
-                decoration: InputDecoration(
-                  hintText: "Input Text without Close Widget",
-                ),
+            ),
+            TextField(
+              keyboardType: TextInputType.text,
+              focusNode: _nodeText4,
+              decoration: InputDecoration(
+                hintText: "Input Text without Close Widget",
               ),
-              TextField(
-                keyboardType: TextInputType.number,
-                focusNode: _nodeText5,
-                decoration: InputDecoration(
-                  hintText: "Input Number with Custom Close Widget",
-                ),
+            ),
+            TextField(
+              keyboardType: TextInputType.number,
+              focusNode: _nodeText5,
+              decoration: InputDecoration(
+                hintText: "Input Number with Custom Close Widget",
               ),
-            ],
-          ),
+            ),
+//            SizedBox(height: 40,),
+            ColorInput(
+              focusNode: _nodeText6,
+              decoration: InputDecoration(
+                  hintText: 'Input Color with Custom Footer',
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/example/lib/custom_input.dart
+++ b/example/lib/custom_input.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 
 /// A field for inputting a color.

--- a/example/lib/custom_input.dart
+++ b/example/lib/custom_input.dart
@@ -37,6 +37,8 @@ class _ColorInputState extends State<ColorInput> {
     return Focus(
       focusNode: widget.focusNode,
       child: Container(
+        // TODO https://github.com/flutter/flutter/issues/33235 - InputDecorator errors without a text child.
+        // This logs errors (child.parent != this) but still renders fine.
         child: InputDecorator(
           decoration: widget.decoration ?? InputDecoration(),
           isFocused: _hasFocus,

--- a/example/lib/custom_input.dart
+++ b/example/lib/custom_input.dart
@@ -1,0 +1,130 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+/// A field for inputting a color.
+class ColorInput extends StatefulWidget {
+  /// Key to look up this widget later. Helps you get the current color.
+  final GlobalKey key;
+  /// Focus node for this input.
+  final FocusNode focusNode;
+  /// The input decoration.
+  final InputDecoration decoration;
+
+  const ColorInput({this.key, this.focusNode, this.decoration}) : super(key: key);
+
+  @override
+  _ColorInputState createState() => _ColorInputState();
+}
+
+class _ColorInputState extends State<ColorInput> {
+
+  Color _color;
+  bool _hasFocus;
+
+  @override
+  void initState() {
+    super.initState();
+    _hasFocus = widget.focusNode.hasFocus;
+  }
+
+  void _onColorPicked(Color newColor) {
+    setState(() {
+      _color = newColor;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      focusNode: widget.focusNode,
+      child: Container(
+        child: InputDecorator(
+          decoration: widget.decoration ?? InputDecoration(),
+          isFocused: _hasFocus,
+          isEmpty: (_color == null),
+          child: GestureDetector(
+              onTap: () {
+                if (!widget.focusNode.hasFocus) {
+                  widget.focusNode.requestFocus();
+                }
+              },
+              child: MergeSemantics(
+                child: Semantics(
+                  focused: _hasFocus,
+                  child: Container(
+                    width: double.maxFinite,
+                    height: 30,
+                    color: _color ?? Colors.transparent,
+                  ),
+                ),
+              )
+          ),
+        ),
+      ),
+      onFocusChange: (newValue) =>
+          setState(() {
+            _hasFocus = newValue;
+            if (_hasFocus) {
+              ColorPickerKeyboard.listener = _onColorPicked;
+            }
+          }),
+    );
+  }
+}
+
+/// A quick example "keyboard" widget for picking a color.
+///
+/// **hacky!** :: Maintains a single global listener reference in a static variable, which [ColorInput]s
+/// use to subscribe to changes.  This can't be good :) Don't have more than one [ColorPickerKeyboard].
+///
+/// For a real implementation, consider using something like a GlobalKey to reference this, and then link
+/// [ColorInput]s to it via some equivalent of a [TextEditingController].
+class ColorPickerKeyboard extends StatelessWidget implements PreferredSizeWidget {
+
+  static const double _kKeyboardHeight = 200;
+
+  /// Public singleton instance.
+  static const ColorPickerKeyboard instance = ColorPickerKeyboard._();
+
+  /// Single listener to this keyboard.
+  static Function(Color pickedColor) listener;
+
+
+  const ColorPickerKeyboard._() : super(); // private constructor
+
+
+  @override
+  Widget build(BuildContext context) {
+
+    final double rows = 3;
+    final double screenWidth = MediaQuery.of(context).size.width;
+    final int colorsCount = Colors.primaries.length;
+    final int colorsPerRow = (colorsCount / rows).ceil();
+    final double itemWidth = screenWidth / colorsPerRow;
+    final double itemHeight = _kKeyboardHeight / rows;
+
+    return Container(
+      height: _kKeyboardHeight,
+      child: Wrap(
+        children: <Widget>[
+          for (final color in Colors.primaries) GestureDetector(
+            onTap: () {
+              if (listener != null) {
+                listener(color);
+              }
+            },
+            child: Container(
+              color: color,
+              width: itemWidth,
+              height: itemHeight,
+            ),
+          )
+        ],
+      ),
+    );
+  }
+
+  @override
+  Size get preferredSize => Size.fromHeight(_kKeyboardHeight);
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -61,7 +61,7 @@ class ScaffoldTest extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      resizeToAvoidBottomInset: true,
+      resizeToAvoidBottomInset: false,
       appBar: AppBar(
         title: Text("Keyboard Actions Sample"),
       ),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,13 +10,13 @@ description: Sample project using keyboard actions.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.0.0-dev.68.0 <3.0.0"
+  sdk: ">=2.3.0 <3.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
 
-  keyboard_actions: 
+  keyboard_actions:
     path: ../
 
 

--- a/lib/keyboard_actions.dart
+++ b/lib/keyboard_actions.dart
@@ -197,7 +197,6 @@ class FormKeyboardActionState extends State<FormKeyboardActions>
       _currentAction = action;
       currentIndex = nextIndex;
       FocusScope.of(context).requestFocus(_currentAction.focusNode);
-//      _showBar(true);  todo: Focus will change, causing this to happen anyway
     }
   }
 
@@ -233,9 +232,13 @@ class FormKeyboardActionState extends State<FormKeyboardActions>
       _insertOverlay();
     } else if (!showBar && isShowing) {
       _removeOverlay();
+    } else if (showBar && isShowing) {
+      _overlayEntry.markNeedsBuild();
     }
 
-    _updateOffset();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _updateOffset();
+    });
   }
 
   @override
@@ -345,7 +348,6 @@ class FormKeyboardActionState extends State<FormKeyboardActions>
           : CrossFadeState.showSecond,
       firstChild: Container(
         height: _kBarSize,
-        color: config.keyboardBarColor ?? Colors.grey[200],
         width: MediaQuery.of(context).size.width,
         child: Row(
           children: [
@@ -411,7 +413,6 @@ class FormKeyboardActionState extends State<FormKeyboardActions>
       width: double.maxFinite,
       child: BottomAreaAvoider(
           areaToAvoid: _offset,
-//          duration: Duration(seconds: 1),
           autoScroll: true,
           child: widget.child),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,9 @@ dependencies:
   # todo: waiting on SingleChildScrollView change.
   # For now, keyboard_avoider uses a LayoutBuilder when there's no
   keyboard_avoider:
-    path: ../keyboard_avoider
+    git:
+      url: https://github.com/jaysephjw/keyboard_avoider
+      ref: bottom-area-avoider
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: Diego Velásquez <diegoveloper@gmail.com>
 homepage: https://github.com/diegoveloper/flutter_keyboard_actions/
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.3.0 <3.0.0"
 
 dependencies:
   flutter:
@@ -14,7 +14,8 @@ dependencies:
   # todo: narrow this version
   # todo: waiting on SingleChildScrollView change.
   # For now, keyboard_avoider uses a LayoutBuilder when there's no
-  keyboard_avoider: ^0.1.2
+  keyboard_avoider:
+    path: ../keyboard_avoider
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec


### PR DESCRIPTION
Let each keyboard action have a custom footer widget, like this: 
```
 KeyboardAction(
          focusNode: _nodeText6,
          footerBuilder: (_) => PreferredSize(
              child: SizedBox(height: 40, child: Center(child: Text('Custom Footer'),)),
              preferredSize: Size.fromHeight(40)),
        ),
```
<img width="350" alt="Screen Shot 2019-05-22 at 5 46 50 PM" src="https://user-images.githubusercontent.com/3268245/58218221-0409f200-7cbb-11e9-91d8-592f2e99fa8a.png">

For more fun, use that widget as a custom keyboard with your custom input:

<img width="350" alt="Screen Shot 2019-05-22 at 5 46 54 PM" src="https://user-images.githubusercontent.com/3268245/58218234-0ec48700-7cbb-11e9-81b6-e61658f4d200.png">

* Wrap a BottomAreaAvoider instead of KeyboardAvoider so we can have better control over how the content resizes. 
* Resize the BottomAreaAvoider based on the bar height, system keyboard height, and footer height.
* update example with example custom inputs