### PR TITLE
Add safe area to keyboard actions

### DIFF
--- a/lib/keyboard_actions.dart
+++ b/lib/keyboard_actions.dart
@@ -360,50 +360,52 @@ class FormKeyboardActionState extends State<FormKeyboardActions>
       firstChild: Container(
         height: _kBarSize,
         width: MediaQuery.of(context).size.width,
-        child: Row(
-          children: [
-            config.nextFocus
-                ? IconButton(
-                    icon: Icon(Icons.keyboard_arrow_up),
-                    tooltip: 'Previous',
-                    onPressed: _previousIndex != null ? _onTapUp : null,
-                  )
-                : SizedBox(),
-            config.nextFocus
-                ? IconButton(
-                    icon: Icon(Icons.keyboard_arrow_down),
-                    tooltip: 'Next',
-                    onPressed: _nextIndex != null ? _onTapDown : null,
-                  )
-                : SizedBox(),
-            Spacer(),
-            _currentAction?.displayCloseWidget != null &&
-                    _currentAction.displayCloseWidget
-                ? Padding(
-                    padding: const EdgeInsets.all(5.0),
-                    child: InkWell(
-                      onTap: () {
-                        if (_currentAction?.onTapAction != null) {
-                          _currentAction.onTapAction();
-                        }
-                        _clearFocus();
-                      },
-                      child: _currentAction?.closeWidget ??
-                          Container(
-                            padding: EdgeInsets.symmetric(
-                                vertical: 8.0, horizontal: 12.0),
-                            child: Text(
-                              "Done",
-                              style: TextStyle(
-                                fontSize: 16.0,
-                                fontWeight: FontWeight.w500,
+        child: SafeArea(top: false, bottom: false,
+          Row(
+            children: [
+              config.nextFocus
+                  ? IconButton(
+                      icon: Icon(Icons.keyboard_arrow_up),
+                      tooltip: 'Previous',
+                      onPressed: _previousIndex != null ? _onTapUp : null,
+                    )
+                  : SizedBox(),
+              config.nextFocus
+                  ? IconButton(
+                      icon: Icon(Icons.keyboard_arrow_down),
+                      tooltip: 'Next',
+                      onPressed: _nextIndex != null ? _onTapDown : null,
+                    )
+                  : SizedBox(),
+              Spacer(),
+              _currentAction?.displayCloseWidget != null &&
+                      _currentAction.displayCloseWidget
+                  ? Padding(
+                      padding: const EdgeInsets.all(5.0),
+                      child: InkWell(
+                        onTap: () {
+                          if (_currentAction?.onTapAction != null) {
+                            _currentAction.onTapAction();
+                          }
+                          _clearFocus();
+                        },
+                        child: _currentAction?.closeWidget ??
+                            Container(
+                              padding: EdgeInsets.symmetric(
+                                  vertical: 8.0, horizontal: 12.0),
+                              child: Text(
+                                "Done",
+                                style: TextStyle(
+                                  fontSize: 16.0,
+                                  fontWeight: FontWeight.w500,
+                                ),
                               ),
                             ),
-                          ),
-                    ),
-                  )
-                : SizedBox(),
-          ],
+                      ),
+                    )
+                  : SizedBox(),
+            ],
+          ),
         ),
       ),
       secondChild: Container(),


### PR DESCRIPTION
currently, on iphone X and newer, when in landscape mode, the keyboard actions can get covered by the notch:

<img width="1048" alt="Screen Shot 2019-06-15 at 2 12 07 PM" src="https://user-images.githubusercontent.com/1630091/59554954-3edd0e00-8f79-11e9-8860-ca26d7ad0807.png">

This adds SafeArea support to the sides so that doesn't happen:

<img width="1048" alt="Screen Shot 2019-06-15 at 2 23 06 PM" src="https://user-images.githubusercontent.com/1630091/59554957-4dc3c080-8f79-11e9-9d0c-44337cd212a8.png">

and in portrait mode, everything is as expected:

<img width="584" alt="Screen Shot 2019-06-15 at 2 25 11 PM" src="https://user-images.githubusercontent.com/1630091/59554967-76e45100-8f79-11e9-82a9-c012bb713250.png">

It also includes the previous PR, which has already been merged. Let me know if you need me to redo this one without the tooltips.
