### PR TITLE
bugfix: properlly pass autoScroll through to BottomAreaAvoider

### DIFF
--- a/lib/keyboard_actions.dart
+++ b/lib/keyboard_actions.dart
@@ -457,7 +457,7 @@ class FormKeyboardActionState extends State<FormKeyboardActions>
       child: SizedBox(
         width: double.maxFinite,
         child: BottomAreaAvoider(
-            areaToAvoid: _offset, autoScroll: true, child: widget.child),
+            areaToAvoid: _offset, autoScroll: widget.autoScroll, child: widget.child),
       ),
     );
   }


### PR DESCRIPTION
In looking at #38, I discovered the autoScroll flag isn't being honored. Here's the fix.