### PR TITLE
prepend the bug

### DIFF
--- a/lib/keyboard_actions.dart
+++ b/lib/keyboard_actions.dart
@@ -166,7 +166,7 @@ class KeyboardActionstate extends State<KeyboardActions>
         }
       });
       //if it is a custom keyboard then wait until the focus was dismissed from the others
-      if (_currentAction.footerBuilder != null) {
+      if (_currentAction?.footerBuilder != null) {
         await Future.delayed(
           Duration(milliseconds: _timeToDismiss.inMilliseconds),
         );


### PR DESCRIPTION
```
════════ Exception caught by services library ══════════════════════════════════════════════════════
The following NoSuchMethodError was thrown during a platform message callback:
The getter 'footerBuilder' was called on null.
Receiver: null
Tried calling: footerBuilder

When the exception was thrown, this was the stack: 
#0      Object.noSuchMethod (dart:core-patch/object_patch.dart:51:5)
#1      KeyboardActionstate._focusChanged (package:keyboard_actions/keyboard_actions.dart:219:26)
#2      KeyboardActionstate.didChangeAppLifecycleState (package:keyboard_actions/keyboard_actions.dart:373:9)
#3      WidgetsBinding.handleAppLifecycleStateChanged (package:flutter/src/widgets/binding.dart:536:16)
#4      SchedulerBinding._handleLifecycleMessage (package:flutter/src/scheduler/binding.dart:285:5)
...
════════════════════════════════════════════════════════════════════════════════════════════════════

════════ (2) Exception caught by services library ══════════════════════════════════════════════════
The getter 'footerBuilder' was called on null.
Receiver: null
Tried calling: footerBuilder
════════════════════════════════════════════════════════════════════════════════════════════════════
``