### PR TITLE
added support for configuring ScrollPhysics in bottom_area_avoider.dart

### DIFF
--- a/lib/external/bottom_area_avoider.dart
+++ b/lib/external/bottom_area_avoider.dart
@@ -39,15 +39,19 @@ class BottomAreaAvoider extends StatefulWidget {
   /// Animation curve. Defaults to [defaultCurve]
   final Curve curve;
 
-  BottomAreaAvoider({
-    Key key,
-    @required this.child,
-    @required this.areaToAvoid,
-    this.autoScroll = false,
-    this.duration = defaultDuration,
-    this.curve = defaultCurve,
-    this.overscroll = defaultOverscroll,
-  })  : //assert(child is ScrollView ? child.controller != null : true),
+  /// The [ScrollPhysics] of the [SingleChildScrollView] which contains child
+  final ScrollPhysics physics;
+
+  BottomAreaAvoider(
+      {Key key,
+      @required this.child,
+      @required this.areaToAvoid,
+      this.autoScroll = false,
+      this.duration = defaultDuration,
+      this.curve = defaultCurve,
+      this.overscroll = defaultOverscroll,
+      this.physics})
+      : //assert(child is ScrollView ? child.controller != null : true),
         assert(areaToAvoid >= 0, 'Cannot avoid a negative area'),
         super(key: key);
 
@@ -102,6 +106,7 @@ class BottomAreaAvoiderState extends State<BottomAreaAvoider> {
         LayoutBuilder(
           builder: (context, constraints) {
             return SingleChildScrollView(
+              physics: widget.physics,
               controller: _scrollController,
               child: ConstrainedBox(
                 constraints: BoxConstraints(

--- a/lib/external/keyboard_avoider.dart
+++ b/lib/external/keyboard_avoider.dart
@@ -25,9 +25,13 @@ class KeyboardAvoider extends StatefulWidget {
   /// See [BottomAreaAvoider.overscroll]
   final double overscroll;
 
+  /// See [BottomAreaAvoider.physics]
+  final ScrollPhysics physics;
+
   KeyboardAvoider({
     Key key,
     @required this.child,
+    this.physics,
     this.duration = BottomAreaAvoider.defaultDuration,
     this.curve = BottomAreaAvoider.defaultCurve,
     this.autoScroll = BottomAreaAvoider.defaultAutoScroll,
@@ -64,6 +68,7 @@ class _KeyboardAvoiderState extends State<KeyboardAvoider>
       curve: widget.curve,
       duration: widget.duration,
       overscroll: widget.overscroll,
+      physics: widget.physics,
     );
   }
 

--- a/lib/keyboard_actions.dart
+++ b/lib/keyboard_actions.dart
@@ -55,8 +55,12 @@ class KeyboardActions extends StatefulWidget {
   /// If you want to add overscroll. Eg: In some cases you have a [TextField] with an error text below that.
   final double overscroll;
 
+  /// If you want to control the scroll physics of [BottomAreaAvoider] which uses a [SingleChildScrollView] to contain the child.
+  final ScrollPhysics bottomAvoiderScrollPhysics;
+
   const KeyboardActions({
     this.child,
+    this.bottomAvoiderScrollPhysics,
     this.enable = true,
     this.autoScroll = true,
     this.isDialog = false,
@@ -343,7 +347,9 @@ class KeyboardActionstate extends State<KeyboardActions>
       return;
     }
 
-    double newOffset = _currentAction.displayActionBar ? _kBarSize : 0; // offset for the actions bar
+    double newOffset = _currentAction.displayActionBar
+        ? _kBarSize
+        : 0; // offset for the actions bar
     newOffset += MediaQuery.of(context)
         .viewInsets
         .bottom; // + offset for the system keyboard
@@ -531,6 +537,7 @@ class KeyboardActionstate extends State<KeyboardActions>
                     milliseconds:
                         (_timeToDismiss.inMilliseconds * 1.8).toInt()),
                 autoScroll: widget.autoScroll,
+                physics: widget.bottomAvoiderScrollPhysics,
                 child: widget.child,
               ),
             ),


### PR DESCRIPTION
Resolves #93 

It will use the default physics (when it's unset) for backward compatibility. 