### PR TITLE
Add null check for `_scrollController` in `scrollToOverscroll`  before using the null-check operator on it

### DIFF
--- a/lib/external/keyboard_avoider/bottom_area_avoider.dart
+++ b/lib/external/keyboard_avoider/bottom_area_avoider.dart
@@ -158,7 +158,7 @@ class BottomAreaAvoiderState extends State<BottomAreaAvoider> {
 
   void scrollToOverscroll() {
     final focused = findFocusedObject(context.findRenderObject());
-    if (focused == null) return;
+    if (focused == null || _scrollController == null) return;
     scrollToObject(focused, _scrollController!, widget.duration, widget.curve,
         widget.overscroll);
   }


### PR DESCRIPTION
Return from `scrollToOverscroll` if `_scrollController` is null, meaning that `autoScroll == false` in `KeyboardActions`.

Closes #161 