### PR TITLE
Do not align items to right when arrows are not displayed

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'sample.dart';
 import 'sample2.dart';
 import 'sample3.dart';
+import 'sample4.dart';
 
 // Application entry-point
 void main() => runApp(MyApp());
@@ -77,6 +78,16 @@ class MyApp extends StatelessWidget {
                     onPressed: () => _openWidget(
                       myContext,
                       Sample3(),
+                    ),
+                  ),
+                  const SizedBox(
+                    height: 25,
+                  ),
+                  ElevatedButton(
+                    child: Text("Custom Sample 4"),
+                    onPressed: () => _openWidget(
+                      myContext,
+                      Sample4(),
                     ),
                   ),
                 ],

--- a/example/lib/sample4.dart
+++ b/example/lib/sample4.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:keyboard_actions/keyboard_actions.dart';
+
+/// Sample [Widget] demonstrating the usage of [KeyboardActionsItem.toolbarAlignment].
+class Sample4 extends StatelessWidget {
+  final _focusSample = FocusNode();
+  final _textController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text("Sample 4"),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.only(top: 15.0, left: 15.0, right: 15.0),
+        child: Center(
+          child: KeyboardActions(
+            tapOutsideBehavior: TapOutsideBehavior.translucentDismiss,
+            config: KeyboardActionsConfig(
+              actions: [
+                KeyboardActionsItem(
+                  toolbarAlignment: MainAxisAlignment.spaceAround,
+                  focusNode: _focusSample,
+                  displayArrows: false,
+                  toolbarButtons: [
+                    (_) {
+                      return IconButton(
+                        icon: Icon(Icons.format_bold),
+                        onPressed: () {},
+                      );
+                    },
+                    (_) {
+                      return IconButton(
+                        icon: Icon(Icons.format_italic),
+                        onPressed: () {},
+                      );
+                    },
+                    (_) {
+                      return IconButton(
+                        icon: Icon(Icons.format_underline),
+                        onPressed: () {},
+                      );
+                    },
+                    (_) {
+                      return IconButton(
+                        icon: Icon(Icons.format_strikethrough),
+                        onPressed: () {},
+                      );
+                    },
+                  ],
+                ),
+              ],
+            ),
+            child: ListView(
+              children: [
+                TextField(
+                  controller: _textController,
+                  focusNode: _focusSample,
+                  decoration: InputDecoration(
+                    labelText: "Sample Input",
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/keyboard_actions.dart
+++ b/lib/keyboard_actions.dart
@@ -514,7 +514,7 @@ class KeyboardActionstate extends State<KeyboardActions>
                   disabledColor: Theme.of(context).disabledColor,
                   onPressed: _nextIndex != null ? _onTapDown : null,
                 ),
-                Spacer(),
+                const Spacer(),
               ],
               if (_currentAction?.displayDoneButton != null &&
                   _currentAction!.displayDoneButton &&

--- a/lib/keyboard_actions.dart
+++ b/lib/keyboard_actions.dart
@@ -496,6 +496,8 @@ class KeyboardActionstate extends State<KeyboardActions>
           top: false,
           bottom: false,
           child: Row(
+            mainAxisAlignment:
+                _currentAction?.toolbarAlignment ?? MainAxisAlignment.end,
             children: [
               if (config!.nextFocus && displayArrows) ...[
                 IconButton(

--- a/lib/keyboard_actions.dart
+++ b/lib/keyboard_actions.dart
@@ -497,27 +497,25 @@ class KeyboardActionstate extends State<KeyboardActions>
           bottom: false,
           child: Row(
             children: [
-              config!.nextFocus && displayArrows
-                  ? IconButton(
-                      icon: Icon(Icons.keyboard_arrow_up),
-                      tooltip: 'Previous',
-                      iconSize: IconTheme.of(context).size!,
-                      color: IconTheme.of(context).color,
-                      disabledColor: Theme.of(context).disabledColor,
-                      onPressed: _previousIndex != null ? _onTapUp : null,
-                    )
-                  : const SizedBox.shrink(),
-              config!.nextFocus && displayArrows
-                  ? IconButton(
-                      icon: Icon(Icons.keyboard_arrow_down),
-                      tooltip: 'Next',
-                      iconSize: IconTheme.of(context).size!,
-                      color: IconTheme.of(context).color,
-                      disabledColor: Theme.of(context).disabledColor,
-                      onPressed: _nextIndex != null ? _onTapDown : null,
-                    )
-                  : const SizedBox.shrink(),
-              Spacer(),
+              if (config!.nextFocus && displayArrows) ...[
+                IconButton(
+                  icon: Icon(Icons.keyboard_arrow_up),
+                  tooltip: 'Previous',
+                  iconSize: IconTheme.of(context).size!,
+                  color: IconTheme.of(context).color,
+                  disabledColor: Theme.of(context).disabledColor,
+                  onPressed: _previousIndex != null ? _onTapUp : null,
+                ),
+                IconButton(
+                  icon: Icon(Icons.keyboard_arrow_down),
+                  tooltip: 'Next',
+                  iconSize: IconTheme.of(context).size!,
+                  color: IconTheme.of(context).color,
+                  disabledColor: Theme.of(context).disabledColor,
+                  onPressed: _nextIndex != null ? _onTapDown : null,
+                ),
+                Spacer(),
+              ],
               if (_currentAction?.displayDoneButton != null &&
                   _currentAction!.displayDoneButton &&
                   (_currentAction!.toolbarButtons == null ||

--- a/lib/keyboard_actions_item.dart
+++ b/lib/keyboard_actions_item.dart
@@ -35,6 +35,11 @@ class KeyboardActionsItem {
   /// This widget must be a PreferredSizeWidget to report its exact height; use [Size.fromHeight]
   final PreferredSizeWidget Function(BuildContext context)? footerBuilder;
 
+  /// Alignment of the row that displays [toolbarButtons]. If you want to show your
+  /// buttons from the left side of the toolbar, you can set [toolbarAlignment] and
+  /// set the value of [displayArrows] to `false`
+  final MainAxisAlignment toolbarAlignment;
+
   const KeyboardActionsItem({
     required this.focusNode,
     this.onTapAction,
@@ -44,5 +49,6 @@ class KeyboardActionsItem {
     this.displayArrows = true,
     this.displayDoneButton = true,
     this.footerBuilder,
+    this.toolbarAlignment = MainAxisAlignment.end,
   });
 }


### PR DESCRIPTION
Previously all toolbar buttons were aligned to the right even when
arrows were not displayed. The proposed changes modify this behavior:
when arrows are hidden, toolbar buttons are aligned to the beginning.
Otherwise, the behavior stays the same.