### PR TITLE
#172 Fix gap between actions bar and page content

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -5,6 +5,7 @@ import 'sample.dart';
 import 'sample2.dart';
 import 'sample3.dart';
 import 'sample4.dart';
+import 'sample5.dart';
 
 // Application entry-point
 void main() => runApp(MyApp());
@@ -88,6 +89,16 @@ class MyApp extends StatelessWidget {
                     onPressed: () => _openWidget(
                       myContext,
                       Sample4(),
+                    ),
+                  ),
+                  const SizedBox(
+                    height: 25,
+                  ),
+                  ElevatedButton(
+                    child: Text("Custom Sample 5"),
+                    onPressed: () => _openWidget(
+                      myContext,
+                      Sample5(),
                     ),
                   ),
                 ],

--- a/example/lib/sample5.dart
+++ b/example/lib/sample5.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:keyboard_actions/keyboard_actions.dart';
+
+/// Sample [Widget] demonstrating the usage of [KeyboardActionsConfig.defaultDoneWidget].
+class Sample5 extends StatelessWidget {
+  final _focusNodes =
+      Iterable<int>.generate(7).map((_) => FocusNode()).toList();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text("Sample 5"),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.only(top: 15.0, left: 15.0, right: 15.0),
+        child: Column(mainAxisSize: MainAxisSize.min, children: [
+          Expanded(
+              flex: 2,
+              child: Center(
+                child: KeyboardActions(
+                  tapOutsideBehavior: TapOutsideBehavior.translucentDismiss,
+                  config: KeyboardActionsConfig(
+                    // Define ``defaultDoneWidget`` only once in the config
+                    defaultDoneWidget: _buildMyDoneWidget(),
+                    actions: _focusNodes
+                        .map((focusNode) =>
+                            KeyboardActionsItem(focusNode: focusNode))
+                        .toList(),
+                  ),
+                  child: ListView.separated(
+                    itemBuilder: (ctx, idx) => TextField(
+                      focusNode: _focusNodes[idx],
+                      keyboardType: TextInputType.text,
+                      decoration: InputDecoration(
+                        fillColor: Colors.red,
+                        filled: true,
+                        labelText: "Field ${idx + 1}",
+                      ),
+                    ),
+                    separatorBuilder: (ctx, idx) =>
+                        const SizedBox(height: 10.0),
+                    itemCount: _focusNodes.length,
+                  ),
+                ),
+              )),
+          Expanded(
+              flex: 1,
+              child: Container(
+                  color: Colors.green,
+                  child: Center(
+                      child: TextButton(
+                    onPressed: () {},
+                    child: Text(
+                      'I take up space below the KeyboardActions',
+                      style: TextStyle(color: Colors.white),
+                    ),
+                  ))))
+        ]),
+      ),
+    );
+  }
+
+  /// Returns the custom [Widget] to be rendered as the *"Done"* button.
+  Widget _buildMyDoneWidget() {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text('My Done Widget'),
+        const SizedBox(width: 10.0),
+        Icon(Icons.arrow_drop_down, size: 20.0),
+      ],
+    );
+  }
+}

--- a/lib/keyboard_actions.dart
+++ b/lib/keyboard_actions.dart
@@ -148,6 +148,21 @@ class KeyboardActionstate extends State<KeyboardActions>
     return nextIndex < _map.length ? nextIndex : null;
   }
 
+  /// The distance from the bottom of the KeyboardActions widget to the
+  /// bottom of the view port.
+  ///
+  /// Used to correctly calculate the offset to "avoid" with BottomAreaAvoider.
+  double get _distanceBelowWidget {
+    final widgetRenderBox =
+        _keyParent.currentContext!.findRenderObject() as RenderBox;
+    final fullHeight = MediaQuery.of(context).size.height;
+    final widgetHeight = widgetRenderBox.size.height;
+    final widgetTop = widgetRenderBox.localToGlobal(Offset.zero).dy;
+    final widgetBottom = widgetTop + widgetHeight;
+    final distanceBelowWidget = fullHeight - widgetBottom;
+    return distanceBelowWidget;
+  }
+
   /// Set the config for the keyboard action bar.
   void setConfig(KeyboardActionsConfig newConfig) {
     clearConfig();
@@ -406,7 +421,13 @@ class KeyboardActionstate extends State<KeyboardActions>
       newOffset +=
           _currentFooter!.preferredSize.height; // + offset for the footer
     }
-    newOffset = newOffset - _localMargin;
+
+    newOffset -= _localMargin;
+    if (!widget.isDialog) {
+      // If you there are widgets etc. under the KeyboardActions widget,
+      // decrease the offset by their height.
+      newOffset -= _distanceBelowWidget;
+    }
 
     if (newOffset < 0) newOffset = 0;
 


### PR DESCRIPTION
Fix a bug where if anything was below the KeyboardActions widget, it created a gap between the actions bar and page content