### PR TITLE
remove unnecessary null aware operators

### DIFF
--- a/lib/external/keyboard_avoider/bottom_area_avoider.dart
+++ b/lib/external/keyboard_avoider/bottom_area_avoider.dart
@@ -81,7 +81,7 @@ class BottomAreaAvoiderState extends State<BottomAreaAvoider> {
     // Add a status listener to the animation after the initial build.
     // Wait a frame so that _animationKey.currentState is not null.
     if (_animationListener == null) {
-      WidgetsBinding.instance!.addPostFrameCallback((_) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
         _animationListener = _paddingAnimationStatusChanged;
         _animationKey.currentState?.animation
             .addStatusListener(_animationListener!);
@@ -147,7 +147,7 @@ class BottomAreaAvoiderState extends State<BottomAreaAvoider> {
       return; // decreased-- do nothing. We only scroll when area to avoid is added (keyboard shown).
     }
     // Need to wait a frame to get the new size (todo: is this still needed? we dont use mediaquery anymore)
-    WidgetsBinding.instance!.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) {
         return; // context is no longer valid
       }

--- a/lib/external/keyboard_avoider/keyboard_avoider.dart
+++ b/lib/external/keyboard_avoider/keyboard_avoider.dart
@@ -49,12 +49,12 @@ class _KeyboardAvoiderState extends State<KeyboardAvoider>
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance!.addObserver(this);
+    WidgetsBinding.instance.addObserver(this);
   }
 
   @override
   void dispose() {
-    WidgetsBinding.instance!.removeObserver(this);
+    WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }
 
@@ -76,7 +76,7 @@ class _KeyboardAvoiderState extends State<KeyboardAvoider>
   @override
   void didChangeMetrics() {
     // Need to wait a frame to get the new size
-    WidgetsBinding.instance!.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       _resize();
     });
   }

--- a/lib/keyboard_actions.dart
+++ b/lib/keyboard_actions.dart
@@ -280,7 +280,7 @@ class KeyboardActionstate extends State<KeyboardActions>
         _overlayEntry!.markNeedsBuild();
       }
       if (_currentAction != null && _currentAction!.footerBuilder != null) {
-        WidgetsBinding.instance!.addPostFrameCallback((_) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
           _updateOffset();
         });
       }
@@ -290,7 +290,7 @@ class KeyboardActionstate extends State<KeyboardActions>
   @override
   void didChangeMetrics() {
     if (PlatformCheck.isAndroid) {
-      final value = WidgetsBinding.instance!.window.viewInsets.bottom;
+      final value = WidgetsBinding.instance.window.viewInsets.bottom;
       bool keyboardIsOpen = value > 0;
       if (PlatformCheck.isAndroid && !keyboardIsOpen) {
         keyboardIsOpen = _currentAction?.focusNode.hasFocus == true;
@@ -304,7 +304,7 @@ class KeyboardActionstate extends State<KeyboardActions>
       }
     }
     // Need to wait a frame to get the new size
-    WidgetsBinding.instance!.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       _updateOffset();
     });
   }
@@ -422,8 +422,8 @@ class KeyboardActionstate extends State<KeyboardActions>
         : 0; // offset for the actions bar
 
     final keyboardHeight = EdgeInsets.fromWindowPadding(
-            WidgetsBinding.instance!.window.viewInsets,
-            WidgetsBinding.instance!.window.devicePixelRatio)
+            WidgetsBinding.instance.window.viewInsets,
+            WidgetsBinding.instance.window.devicePixelRatio)
         .bottom;
 
     newOffset += keyboardHeight; // + offset for the system keyboard
@@ -478,16 +478,16 @@ class KeyboardActionstate extends State<KeyboardActions>
   void dispose() {
     clearConfig();
     _removeOverlay(fromDispose: true);
-    WidgetsBinding.instance!.removeObserver(this);
+    WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }
 
   @override
   void initState() {
-    WidgetsBinding.instance!.addObserver(this);
+    WidgetsBinding.instance.addObserver(this);
     if (widget.enable) {
       setConfig(widget.config);
-      WidgetsBinding.instance!.addPostFrameCallback((_) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
         _onLayout();
         _updateOffset();
       });


### PR DESCRIPTION
Remove unnecessary null aware operators from `instance` of `WidgetsBinding` which has type of `WidgetsBinding` that excludes null