### PR TITLE
add keyboardBarElevation to KeyboardActionsConfig

### DIFF
--- a/lib/keyboard_actions.dart
+++ b/lib/keyboard_actions.dart
@@ -362,7 +362,7 @@ class KeyboardActionstate extends State<KeyboardActions>
             bottom: queryData.viewInsets.bottom,
             child: Material(
               color: config!.keyboardBarColor ?? Colors.grey[200],
-              elevation: 20,
+              elevation: config!.keyboardBarElevation ?? 20,
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: <Widget>[

--- a/lib/keyboard_actions_config.dart
+++ b/lib/keyboard_actions_config.dart
@@ -16,6 +16,9 @@ class KeyboardActionsConfig {
   /// Color of the background to the Custom keyboard buttons
   final Color? keyboardBarColor;
 
+  /// Elevation of the Custom keyboard buttons
+  final double? keyboardBarElevation;
+
   /// Color of the line separator between keyboard and content
   final Color keyboardSeparatorColor;
 
@@ -28,6 +31,7 @@ class KeyboardActionsConfig {
     this.nextFocus = true,
     this.actions,
     this.keyboardBarColor,
+    this.keyboardBarElevation,
     this.keyboardSeparatorColor = Colors.transparent,
     this.defaultDoneWidget,
   });


### PR DESCRIPTION
Adds `keyboardBarElevation` to `KeyboardActionsConfig` to change the current mandatory 20 elevation.

I needed to create only a button to dismiss the widget and have the background behind it transparent. However, with the hard coded 20 value of the elevation property on the `Material` widget in the `KeyboardActions` widget, this is how is looks like:
<img width="435" alt="image" src="https://user-images.githubusercontent.com/50345358/174779593-0ad3788b-51c4-4403-865b-90bea86bd4a6.png">

So with this change the elevation can be changed.