### PR TITLE
removed unfocusing for android on keyboard change

### DIFF
--- a/lib/keyboard_actions.dart
+++ b/lib/keyboard_actions.dart
@@ -292,8 +292,6 @@ class KeyboardActionstate extends State<KeyboardActions>
     if (PlatformCheck.isAndroid) {
       final value = WidgetsBinding.instance.window.viewInsets.bottom;
       bool keyboardIsOpen = value > 0;
-
-      _onKeyboardChanged(keyboardIsOpen);
       isKeyboardOpen = keyboardIsOpen;
     }
     // Need to wait a frame to get the new size

--- a/lib/keyboard_actions.dart
+++ b/lib/keyboard_actions.dart
@@ -292,6 +292,7 @@ class KeyboardActionstate extends State<KeyboardActions>
     if (PlatformCheck.isAndroid) {
       final value = WidgetsBinding.instance.window.viewInsets.bottom;
       bool keyboardIsOpen = value > 0;
+      _onKeyboardChanged(keyboardIsOpen);
       isKeyboardOpen = keyboardIsOpen;
     }
     // Need to wait a frame to get the new size
@@ -489,9 +490,15 @@ class KeyboardActionstate extends State<KeyboardActions>
   var isKeyboardOpen = false;
 
   void _onKeyboardChanged(bool isVisible) {
-    if (!isVisible && isKeyboardOpen) {
+    bool footerHasSize = _checkIfFooterHasSize();
+    if (!isVisible && isKeyboardOpen && !footerHasSize) {
       _clearFocus();
     }
+  }
+
+  bool _checkIfFooterHasSize() {
+    return _currentFooter != null &&
+        (_currentFooter?.preferredSize.height ?? 0) > 0;
   }
 
   /// Build the keyboard action bar based on the current [config].


### PR DESCRIPTION
On moving from android keyboard to custom keyboard, the custom keyboard will come up and then go away instantly. This was caused because we were unfocusing on keyboard change.


