### PR TITLE
Migrate the example app to null safety

### DIFF
--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>9.0</string>
+  <string>11.0</string>
 </dict>
 </plist>

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -184,10 +184,12 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (
@@ -198,6 +200,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -284,7 +287,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -361,7 +364,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -408,7 +411,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -41,5 +41,9 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/example/lib/content.dart
+++ b/example/lib/content.dart
@@ -6,7 +6,7 @@ import 'custom_input.dart';
 class Content extends StatefulWidget {
   final bool isDialog;
 
-  const Content({Key key, this.isDialog = false}) : super(key: key);
+  const Content({Key? key, this.isDialog = false}) : super(key: key);
 
   @override
   _ContentState createState() => _ContentState();
@@ -229,7 +229,7 @@ class _ContentState extends State<Content> {
                 builder: (context, val, hasFocus) {
                   return Container(
                     alignment: Alignment.center,
-                    color: hasFocus ? Colors.grey[300] : Colors.white,
+                    color: hasFocus == true ? Colors.grey[300] : Colors.white,
                     child: Text(
                       val,
                       style:
@@ -245,7 +245,7 @@ class _ContentState extends State<Content> {
                 builder: (context, val, hasFocus) {
                   return Container(
                     width: double.maxFinite,
-                    color: val ?? Colors.transparent,
+                    color: val,
                   );
                 },
               ),

--- a/example/lib/custom_input.dart
+++ b/example/lib/custom_input.dart
@@ -9,7 +9,7 @@ class ColorPickerKeyboard extends StatelessWidget
   final ValueNotifier<Color> notifier;
   static const double _kKeyboardHeight = 200;
 
-  ColorPickerKeyboard({Key key, this.notifier}) : super(key: key);
+  ColorPickerKeyboard({Key? key, required this.notifier}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -50,7 +50,7 @@ class CounterKeyboard extends StatelessWidget
     implements PreferredSizeWidget {
   final ValueNotifier<String> notifier;
 
-  CounterKeyboard({Key key, this.notifier}) : super(key: key);
+  CounterKeyboard({Key? key, required this.notifier}) : super(key: key);
 
   @override
   Size get preferredSize => Size.fromHeight(200);
@@ -109,9 +109,9 @@ class NumericKeyboard extends StatelessWidget
   final FocusNode focusNode;
 
   NumericKeyboard({
-    Key key,
-    this.notifier,
-    this.focusNode,
+    Key? key,
+    required this.notifier,
+    required this.focusNode,
   }) : super(key: key);
 
   @override
@@ -178,31 +178,32 @@ class NumericKeyboard extends StatelessWidget
   }
 
   Widget _buildButton({
-    String text,
-    IconData icon,
-    Color color,
+    String? text,
+    IconData? icon,
+    Color? color,
   }) =>
       NumericButton(
         text: text,
         icon: icon,
         color: color,
-        onTap: () => icon != null ? _onTapBackspace() : _onTapNumber(text),
+        onTap: () => icon != null ? _onTapBackspace() : _onTapNumber(text!),
       );
 }
 
 class NumericButton extends StatelessWidget {
-  final String text;
+  final String? text;
   final VoidCallback onTap;
-  final IconData icon;
-  final Color color;
+  final IconData? icon;
+  final Color? color;
 
   const NumericButton({
-    Key key,
+    Key? key,
     this.text,
-    this.onTap,
+    required this.onTap,
     this.icon,
     this.color,
-  }) : super(key: key);
+  })  : assert((icon != null) != (text != null)),
+        super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -221,7 +222,7 @@ class NumericButton extends StatelessWidget {
                     color: Colors.white,
                   )
                 : Text(
-                    text,
+                    text!,
                     style: TextStyle(
                       color: Colors.white,
                       fontWeight: FontWeight.w300,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -11,7 +11,7 @@ import 'sample5.dart';
 void main() => runApp(MyApp());
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key key}) : super(key: key);
+  const MyApp({Key? key}) : super(key: key);
 
   _openWidget(BuildContext context, Widget widget) =>
       Navigator.of(context).push(

--- a/example/lib/sample2.dart
+++ b/example/lib/sample2.dart
@@ -56,9 +56,9 @@ class MyCustomBarWidget extends StatelessWidget implements PreferredSizeWidget {
   final TextEditingController controller;
 
   const MyCustomBarWidget({
-    Key key,
-    this.node,
-    this.controller,
+    Key? key,
+    required this.node,
+    required this.controller,
   }) : super(key: key);
 
   @override

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,7 +14,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.3.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
This PR fixes #228.

Changes done:
- Update the lower bound of the sdk version from 2.3 to 2.12 to support null safety
- Migrate the code to null safety
