### PR TITLE
Fix deprecation warnings

### DIFF
--- a/lib/external/keyboard_avoider/bottom_area_avoider.dart
+++ b/lib/external/keyboard_avoider/bottom_area_avoider.dart
@@ -175,7 +175,7 @@ RenderObject? findFocusedObject(RenderObject? root) {
     final config = SemanticsConfiguration();
     //ignore: invalid_use_of_protected_member
     node.describeSemanticsConfiguration(config);
-    if (config.isFocused) {
+    if (config.isFocused ?? false) {
       return node;
     }
     node.visitChildrenForSemantics((child) {

--- a/lib/external/keyboard_avoider/bottom_area_avoider.dart
+++ b/lib/external/keyboard_avoider/bottom_area_avoider.dart
@@ -175,7 +175,7 @@ RenderObject? findFocusedObject(RenderObject? root) {
     final config = SemanticsConfiguration();
     //ignore: invalid_use_of_protected_member
     node.describeSemanticsConfiguration(config);
-    if (config.isFocused ?? false) {
+    if (config.isFocused) {
       return node;
     }
     node.visitChildrenForSemantics((child) {

--- a/lib/external/keyboard_avoider/bottom_area_avoider.dart
+++ b/lib/external/keyboard_avoider/bottom_area_avoider.dart
@@ -175,6 +175,7 @@ RenderObject? findFocusedObject(RenderObject? root) {
     final config = SemanticsConfiguration();
     //ignore: invalid_use_of_protected_member
     node.describeSemanticsConfiguration(config);
+    // ignore: dead_null_aware_expression
     if (config.isFocused ?? false) {
       return node;
     }

--- a/lib/keyboard_actions.dart
+++ b/lib/keyboard_actions.dart
@@ -294,7 +294,7 @@ class KeyboardActionstate extends State<KeyboardActions>
   @override
   void didChangeMetrics() {
     if (PlatformCheck.isAndroid) {
-      final value = WidgetsBinding.instance.window.viewInsets.bottom;
+      final value = View.of(context).viewInsets.bottom;
       bool keyboardIsOpen = value > 0;
       _onKeyboardChanged(keyboardIsOpen);
       isKeyboardOpen = keyboardIsOpen;
@@ -417,9 +417,9 @@ class KeyboardActionstate extends State<KeyboardActions>
         ? _kBarSize
         : 0; // offset for the actions bar
 
-    final keyboardHeight = EdgeInsets.fromWindowPadding(
-            WidgetsBinding.instance.window.viewInsets,
-            WidgetsBinding.instance.window.devicePixelRatio)
+    final keyboardHeight = EdgeInsets.fromViewPadding(
+            View.of(context).viewInsets,
+            View.of(context).devicePixelRatio)
         .bottom;
 
     newOffset += keyboardHeight; // + offset for the system keyboard


### PR DESCRIPTION
Fixes these deprecation warnings:
- 'EdgeInsets.fromWindowPadding' is deprecated and shouldn't be used. Use EdgeInsets.fromViewPadding instead. This feature was deprecated after v3.8.0-14.0.pre.

- 'window' is deprecated and shouldn't be used. Look up the current FlutterView from the context via View.of(context) or consult the PlatformDispatcher directly instead. Deprecated to prepare for the upcoming multi-window support. This feature was deprecated after v3.7.0-32.0.pre.