### PR TITLE
feat: KeyboardActions add a scrollController field

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:example/content.dart';
+import 'package:example/sample6.dart';
 import 'package:flutter/material.dart';
 
 import 'sample.dart';
@@ -99,6 +100,16 @@ class MyApp extends StatelessWidget {
                     onPressed: () => _openWidget(
                       myContext,
                       Sample5(),
+                    ),
+                  ),
+                  const SizedBox(
+                    height: 25,
+                  ),
+                  ElevatedButton(
+                    child: Text("Custom Sample 6"),
+                    onPressed: () => _openWidget(
+                      myContext,
+                      Sample6(),
                     ),
                   ),
                 ],

--- a/example/lib/sample6.dart
+++ b/example/lib/sample6.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:keyboard_actions/keyboard_actions.dart';
+
+/// Sample [Widget] demonstrating the usage of [KeyboardActions.scrollController].
+/// The child of KeyboardActions is not a ScrollView, but it contains a ScrollView internally.
+class Sample6 extends StatelessWidget {
+  final ScrollController _scrollController = ScrollController();
+
+  final _focusNodes =
+      Iterable<int>.generate(20).map((_) => FocusNode()).toList();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: KeyboardActions(
+        scrollController: _scrollController,
+        config: KeyboardActionsConfig(
+          actions: _focusNodes
+              .map((focusNode) => KeyboardActionsItem(focusNode: focusNode))
+              .toList(),
+        ),
+        child: BasePage(
+          title: Text("Sample 6"),
+          scrollController: _scrollController,
+          itemCount: _focusNodes.length,
+          itemBuilder: (ctx, idx) => TextField(
+            focusNode: _focusNodes[idx],
+            keyboardType: TextInputType.text,
+            decoration: InputDecoration(
+              fillColor: Colors.red,
+              filled: true,
+              labelText: "Field ${idx + 1}",
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class BasePage extends StatelessWidget {
+  final Widget title;
+
+  final ScrollController? scrollController;
+
+  final int itemCount;
+
+  final NullableIndexedWidgetBuilder itemBuilder;
+
+  final NullableIndexedWidgetBuilder? separatorBuilder;
+
+  const BasePage(
+      {required this.title,
+      this.scrollController,
+      this.itemCount = 0,
+      required this.itemBuilder,
+      this.separatorBuilder});
+
+  @override
+  Widget build(BuildContext context) {
+    var mediaQuery = MediaQuery.of(context);
+    return CustomScrollView(
+      controller: scrollController,
+      slivers: [
+        SliverAppBar(
+          title: title,
+          floating: true,
+          pinned: true,
+        ),
+        SliverPadding(
+          padding: EdgeInsets.all(15.0).copyWith(
+              bottom: mediaQuery.padding.bottom > 0
+                  ? mediaQuery.padding.bottom
+                  : 15.0),
+          sliver: SliverList.separated(
+            itemCount: itemCount,
+            itemBuilder: itemBuilder,
+            separatorBuilder:
+                separatorBuilder ?? (ctx, idx) => const SizedBox(height: 10.0),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/external/keyboard_avoider/bottom_area_avoider.dart
+++ b/lib/external/keyboard_avoider/bottom_area_avoider.dart
@@ -42,6 +42,9 @@ class BottomAreaAvoider extends StatefulWidget {
   /// The [ScrollPhysics] of the [SingleChildScrollView] which contains child
   final ScrollPhysics? physics;
 
+  /// The [ScrollController] is child use
+  final ScrollController? scrollController;
+
   BottomAreaAvoider(
       {Key? key,
       required this.child,
@@ -50,6 +53,7 @@ class BottomAreaAvoider extends StatefulWidget {
       this.duration = defaultDuration,
       this.curve = defaultCurve,
       this.overscroll = defaultOverscroll,
+      this.scrollController,
       this.physics})
       : //assert(child is ScrollView ? child.controller != null : true),
         assert(areaToAvoid >= 0, 'Cannot avoid a negative area'),
@@ -88,7 +92,12 @@ class BottomAreaAvoiderState extends State<BottomAreaAvoider> {
             .addStatusListener(_animationListener!);
       });
     }
-
+    // If [child] use [ScrollController]
+    // and embed the [child] directly in an [AnimatedContainer].
+    if (widget.scrollController != null) {
+      _scrollController = widget.scrollController;
+      return _buildAnimatedContainer(widget.child);
+    }
     // If [child] is a [ScrollView], get its [ScrollController]
     // and embed the [child] directly in an [AnimatedContainer].
     if (widget.child is ScrollView) {

--- a/lib/external/keyboard_avoider/keyboard_avoider.dart
+++ b/lib/external/keyboard_avoider/keyboard_avoider.dart
@@ -28,10 +28,14 @@ class KeyboardAvoider extends StatefulWidget {
   /// See [BottomAreaAvoider.physics]
   final ScrollPhysics? physics;
 
+  /// [ScrollController] used by child
+  final ScrollController? scrollController;
+
   KeyboardAvoider({
     Key? key,
     required this.child,
     this.physics,
+    this.scrollController,
     this.duration = BottomAreaAvoider.defaultDuration,
     this.curve = BottomAreaAvoider.defaultCurve,
     this.autoScroll = BottomAreaAvoider.defaultAutoScroll,

--- a/lib/keyboard_actions.dart
+++ b/lib/keyboard_actions.dart
@@ -80,6 +80,9 @@ class KeyboardActions extends StatefulWidget {
   /// If you want to control the scroll physics of [BottomAreaAvoider] which uses a [SingleChildScrollView] to contain the child.
   final ScrollPhysics? bottomAvoiderScrollPhysics;
 
+  /// [ScrollController] used by child
+  final ScrollController? scrollController;
+
   /// If you are using [KeyboardActions] for just one textfield and don't need to scroll the content set this to `true`
   final bool disableScroll;
 
@@ -92,6 +95,7 @@ class KeyboardActions extends StatefulWidget {
   const KeyboardActions(
       {this.child,
       this.bottomAvoiderScrollPhysics,
+      this.scrollController,
       this.enable = true,
       this.autoScroll = true,
       this.isDialog = false,
@@ -617,6 +621,7 @@ class KeyboardActionstate extends State<KeyboardActions>
                         (_timeToDismiss.inMilliseconds * 1.8).toInt()),
                 autoScroll: widget.autoScroll,
                 physics: widget.bottomAvoiderScrollPhysics,
+                scrollController: widget.scrollController,
                 child: widget.child,
               ),
             ),


### PR DESCRIPTION
There may be the following situations. I think it will be more flexible to add ScrollController.

``` dart
KeyboardActions(
  config: KeyboardActionsConfig(),
  scrollController: scrollController,
  child: RefreshIndicator(
    onRefresh: _onRefresh,
    child: ListView.builder(
      controller: scrollController,
      itemCount: items.length,
      itemBuilder: (context, index) {
        return ListTile(title: Text(items[index]));
      },
    ),
  ),
);
```