### PR TITLE
修复: Android adjustResize 模式下键盘工具栏定位不正确

### DIFF
--- a/lib/keyboard_actions.dart
+++ b/lib/keyboard_actions.dart
@@ -125,6 +125,7 @@ class KeyboardActionstate extends State<KeyboardActions>
   int? _currentIndex = 0;
   OverlayEntry? _overlayEntry;
   double _offset = 0;
+  double _cachedKeyboardHeight = 0;
   PreferredSizeWidget? _currentFooter;
   bool _dismissAnimationNeeded = true;
   final _keyParent = GlobalKey();
@@ -298,7 +299,7 @@ class KeyboardActionstate extends State<KeyboardActions>
   @override
   void didChangeMetrics() {
     if (PlatformCheck.isAndroid) {
-      final value = View.of(context).viewInsets.bottom;
+      final value = WidgetsBinding.instance.platformDispatcher.views.first.viewInsets.bottom;
       bool keyboardIsOpen = value > 0;
       _onKeyboardChanged(keyboardIsOpen);
       isKeyboardOpen = keyboardIsOpen;
@@ -306,6 +307,7 @@ class KeyboardActionstate extends State<KeyboardActions>
     // Need to wait a frame to get the new size
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _updateOffset();
+      _overlayEntry?.markNeedsBuild();
     });
   }
 
@@ -335,7 +337,6 @@ class KeyboardActionstate extends State<KeyboardActions>
           ? _currentAction!.footerBuilder!(context)
           : null;
 
-      final queryData = MediaQuery.of(context);
       return Stack(
         children: [
           if (widget.tapOutsideBehavior != TapOutsideBehavior.none ||
@@ -359,7 +360,7 @@ class KeyboardActionstate extends State<KeyboardActions>
           Positioned(
             left: 0,
             right: 0,
-            bottom: queryData.viewInsets.bottom,
+            bottom: _cachedKeyboardHeight,
             child: Material(
               color: config!.keyboardBarColor ?? Colors.grey[200],
               elevation: config!.keyboardBarElevation ?? 20,
@@ -383,6 +384,11 @@ class KeyboardActionstate extends State<KeyboardActions>
       );
     });
     os.insert(_overlayEntry!);
+    Future.delayed(const Duration(milliseconds: 500), () {
+      if (!mounted) return;
+      _updateOffset();
+      _overlayEntry?.markNeedsBuild();
+    });
   }
 
   /// Remove the overlay bar. Call when losing focus or being dismissed.
@@ -422,10 +428,11 @@ class KeyboardActionstate extends State<KeyboardActions>
         : 0; // offset for the actions bar
 
     final keyboardHeight = EdgeInsets.fromViewPadding(
-            View.of(context).viewInsets,
-            View.of(context).devicePixelRatio)
+            WidgetsBinding.instance.platformDispatcher.views.first.viewInsets,
+            WidgetsBinding.instance.platformDispatcher.views.first.devicePixelRatio)
         .bottom;
 
+    _cachedKeyboardHeight = keyboardHeight;
     newOffset += keyboardHeight; // + offset for the system keyboard
 
     if (_currentFooter != null) {
@@ -490,6 +497,7 @@ class KeyboardActionstate extends State<KeyboardActions>
       WidgetsBinding.instance.addPostFrameCallback((_) {
         _onLayout();
         _updateOffset();
+        _overlayEntry?.markNeedsBuild();
       });
     }
     super.initState();


### PR DESCRIPTION
- 将 View.of(context) 替换为 WidgetsBinding.instance.platformDispatcher.views.first，确保在 adjustResize 模式下能获取真实的 viewInsets
- overlay 工具栏使用 _cachedKeyboardHeight 定位，替代 MediaQuery.viewInsets.bottom
- didChangeMetrics 和 initState 中触发 overlay 重建
- _insertOverlay 后延迟 500ms 重建 overlay，等待键盘弹出动画完成