### PR TITLE
Fix keyboard action bar clashing with iOS 26's rounded keyboard.

### DIFF
--- a/lib/external/platform_check/platform_check.dart
+++ b/lib/external/platform_check/platform_check.dart
@@ -8,6 +8,12 @@ abstract class PlatformCheck {
   static bool get isLinux => currentPlatform == PlatformCheckType.Linux;
   static bool get isAndroid => currentPlatform == PlatformCheckType.Android;
   static bool get isIOS => currentPlatform == PlatformCheckType.IOS;
+
+  /// True on iOS 26 ("Liquid Glass") and above, where the system keyboard
+  /// has rounded top corners. False on other platforms, or on iOS if the
+  /// version string can't be parsed (so unknown versions fall back to the
+  /// pre-iOS-26 flat-keyboard look rather than guessing).
+  static bool get isIOS26OrAbove => isIOS && (iosMajorVersion ?? 0) >= 26;
 }
 
 enum PlatformCheckType { Web, Windows, Linux, MacOS, Android, Fuchsia, IOS }

--- a/lib/external/platform_check/platform_io.dart
+++ b/lib/external/platform_check/platform_io.dart
@@ -9,3 +9,11 @@ PlatformCheckType get currentPlatform {
   if (Platform.isIOS) return PlatformCheckType.IOS;
   return PlatformCheckType.Android;
 }
+
+/// The device's iOS major version (e.g. 26 for "Version 26.0 (Build ...)"),
+/// or null if not on iOS or the version string can't be parsed.
+int? get iosMajorVersion {
+  if (!Platform.isIOS) return null;
+  final match = RegExp(r'\d+').firstMatch(Platform.operatingSystemVersion);
+  return match == null ? null : int.tryParse(match.group(0)!);
+}

--- a/lib/external/platform_check/platform_web.dart
+++ b/lib/external/platform_check/platform_web.dart
@@ -2,3 +2,5 @@ import 'platform_check.dart';
 
 //Default to web, the platform_io class will override this if it gets imported.
 PlatformCheckType get currentPlatform => PlatformCheckType.Web;
+
+int? get iosMajorVersion => null;

--- a/lib/keyboard_actions.dart
+++ b/lib/keyboard_actions.dart
@@ -15,6 +15,11 @@ export 'keyboard_custom.dart';
 const double _kBarSize = 45.0;
 const Duration _timeToDismiss = Duration(milliseconds: 110);
 
+/// Breathing room between the bar and the system keyboard on iOS, where the
+/// keyboard's rounded top corners otherwise look like they're touching a
+/// flat-edged bar.
+const double _kKeyboardGap = 8.0;
+
 enum KeyboardActionsPlatform {
   ANDROID,
   IOS,
@@ -336,6 +341,18 @@ class KeyboardActionstate extends State<KeyboardActions>
           : null;
 
       final queryData = MediaQuery.of(context);
+      final barColor = config!.keyboardBarColor ?? Colors.grey[200];
+      final keyboardShowing = queryData.viewInsets.bottom > 0;
+      // iOS 26's system keyboard has rounded top corners, which leaves a
+      // visible notch beside a bar with square corners sitting flush against
+      // it. Rounding the bar to match and lifting it off the keyboard by a
+      // small gap makes it read as its own floating element instead of a
+      // disconnected strip touching the keyboard.
+      final barRadius = PlatformCheck.isIOS && keyboardShowing
+          ? const Radius.circular(20)
+          : Radius.zero;
+      final keyboardGap =
+          PlatformCheck.isIOS && keyboardShowing ? _kKeyboardGap : 0.0;
       return Stack(
         children: [
           if (widget.tapOutsideBehavior != TapOutsideBehavior.none ||
@@ -359,10 +376,12 @@ class KeyboardActionstate extends State<KeyboardActions>
           Positioned(
             left: 0,
             right: 0,
-            bottom: queryData.viewInsets.bottom,
+            bottom: queryData.viewInsets.bottom + keyboardGap,
             child: Material(
-              color: config!.keyboardBarColor ?? Colors.grey[200],
+              color: barColor,
               elevation: config!.keyboardBarElevation ?? 20,
+              borderRadius: BorderRadius.all(barRadius),
+              clipBehavior: Clip.antiAlias,
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: <Widget>[
@@ -427,6 +446,10 @@ class KeyboardActionstate extends State<KeyboardActions>
         .bottom;
 
     newOffset += keyboardHeight; // + offset for the system keyboard
+
+    if (PlatformCheck.isIOS && keyboardHeight > 0) {
+      newOffset += _kKeyboardGap; // + gap lifting the bar off the keyboard
+    }
 
     if (_currentFooter != null) {
       newOffset +=

--- a/lib/keyboard_actions.dart
+++ b/lib/keyboard_actions.dart
@@ -348,11 +348,11 @@ class KeyboardActionstate extends State<KeyboardActions>
       // it. Rounding the bar to match and lifting it off the keyboard by a
       // small gap makes it read as its own floating element instead of a
       // disconnected strip touching the keyboard.
-      final barRadius = PlatformCheck.isIOS && keyboardShowing
+      final barRadius = PlatformCheck.isIOS26OrAbove && keyboardShowing
           ? const Radius.circular(20)
           : Radius.zero;
       final keyboardGap =
-          PlatformCheck.isIOS && keyboardShowing ? _kKeyboardGap : 0.0;
+          PlatformCheck.isIOS26OrAbove && keyboardShowing ? _kKeyboardGap : 0.0;
       return Stack(
         children: [
           if (widget.tapOutsideBehavior != TapOutsideBehavior.none ||
@@ -447,7 +447,7 @@ class KeyboardActionstate extends State<KeyboardActions>
 
     newOffset += keyboardHeight; // + offset for the system keyboard
 
-    if (PlatformCheck.isIOS && keyboardHeight > 0) {
+    if (PlatformCheck.isIOS26OrAbove && keyboardHeight > 0) {
       newOffset += _kKeyboardGap; // + gap lifting the bar off the keyboard
     }
 


### PR DESCRIPTION
## Fix keyboard action bar clashing with iOS 26's rounded keyboard

### Problem

iOS 26 ("Liquid Glass") redesigned the system keyboard with rounded top corners instead of a flat rectangle. Since `KeyboardActions` renders its action bar as a flush, square-cornered `Material` sitting directly on top of the keyboard (`bottom: viewInsets.bottom`), the bar's flat edges now visibly clash with the keyboard's new rounded corners — the two shapes don't meet cleanly, leaving an ugly seam/notch on either side.

### Root cause

Initially this looked like a transparency issue (iOS 26's keyboard is known to reveal whatever is drawn underneath at its rounded corners — see [flutter/flutter#179482](https://github.com/flutter/flutter/issues/179482)). Pixel-level inspection of an actual device screenshot showed otherwise: the area between the bar and the keys is **opaque native keyboard chrome** (Apple's own rounded tray + drop shadow), not a transparent gap. So no amount of Flutter-side background color can "show through" there — the real problem is a **shape/color mismatch between two adjacent opaque elements**, not a rendering gap.

### Fix

- Round the action bar's corners and lift it off the keyboard by a small gap (8px), so it reads as its own floating element that echoes the keyboard's new rounded style instead of a flush, disconnected strip.
- Added `PlatformCheck.isIOS26OrAbove`, which parses `Platform.operatingSystemVersion` to detect the actual OS version (no new dependency — uses `dart:io`, already conditionally imported by this package's existing `PlatformCheck` for web compatibility).
- The new rounding/gap treatment is gated behind `isIOS26OrAbove` **and** only applied while the system keyboard is actually showing, so:
  - Android is unaffected.
  - iOS versions before 26 (flat keyboard, no mismatch) keep their existing flush, square-cornered appearance.
  - Custom `footerBuilder` keyboards (no system keyboard) are unaffected.
- `KeyboardActionstate._updateOffset()` was updated in lockstep so the extra gap is included in the space reserved for content avoidance — scrollable content still stops exactly at the top of the bar.

### Files changed

- `lib/keyboard_actions.dart` — rounded corners + gap on the bar's `Material`, updated offset calculation.
- `lib/external/platform_check/platform_check.dart`, `platform_io.dart`, `platform_web.dart` — new `isIOS26OrAbove` / `iosMajorVersion` version detection.

### Testing

- `flutter analyze` passes with no issues.
- Manually verified on an iOS 26.5 simulator (iPhone 17 Pro) using the example app — before/after comparison confirms the bar now sits as a rounded, separated element above the keyboard instead of a flush rectangle with a visible seam.
- Confirmed no visual change on Android and on the existing custom-footer-keyboard demos.


###  Screenshots
| Before | After |
|--------|--------|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-27 at 10 20 21" src="https://github.com/user-attachments/assets/8f39fc6b-349b-4dd2-9ae0-ddcc13adf77e" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-27 at 00 22 05" src="https://github.com/user-attachments/assets/f42db135-2c06-4400-94c9-9e5775213984" /> | 